### PR TITLE
[BW-004a] Evaluate command skeleton + EvaluationConfig models

### DIFF
--- a/brain_wrought_harness/cli.py
+++ b/brain_wrought_harness/cli.py
@@ -1,6 +1,12 @@
 """brain-wrought CLI entry point."""
+from __future__ import annotations
+
+import hashlib
+from typing import Annotated
 
 import typer
+
+from brain_wrought_harness.models import EvaluationConfig
 
 app = typer.Typer(
     name="brain-wrought",
@@ -28,6 +34,28 @@ def submit(
     """Submit officially to Brain-Wrought leaderboard."""
     typer.echo("Official submission coming in Phase 4.")
     typer.echo(f"Image: {image}, config: {submission_yaml}")
+
+
+@app.command()
+def evaluate(
+    docker_image: Annotated[str, typer.Argument(help="Docker image to evaluate")],
+    seed: Annotated[int, typer.Option(help="Evaluation seed")] = 42,
+    fixture_index: Annotated[int, typer.Option(help="Fixture index")] = 0,
+    dry_run: Annotated[bool, typer.Option(help="Print config, skip Docker")] = False,
+) -> None:
+    """Evaluate a Docker image against a Brain-Wrought fixture."""
+    submission_hash = hashlib.sha256(docker_image.encode()).hexdigest()
+    config = EvaluationConfig(
+        submission_hash=submission_hash,
+        docker_image=docker_image,
+        evaluation_seed=seed,
+        fixture_index=fixture_index,
+    )
+    if dry_run:
+        typer.echo(config.model_dump_json(indent=2))
+        return
+    typer.echo("[dry_run=False] Docker evaluation not yet implemented")
+    raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/brain_wrought_harness/models.py
+++ b/brain_wrought_harness/models.py
@@ -1,0 +1,32 @@
+"""Harness data contracts."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class EvaluationConfig(BaseModel):
+    submission_hash: str
+    docker_image: str
+    harness_version: str = "0.1.0"
+    evaluation_seed: int = 42
+    fixture_index: int = 0
+    model_config = {"frozen": True}
+
+
+class AxisResult(BaseModel):
+    axis: Literal["retrieval", "ingestion", "assistant"]
+    score: float = Field(ge=0.0, le=1.0)
+    detail: dict[str, object] = Field(default_factory=dict)
+    model_config = {"frozen": True}
+
+
+class EvaluationResult(BaseModel):
+    submission_hash: str
+    harness_version: str
+    axis_results: list[AxisResult]
+    composite_score: float = Field(ge=0.0, le=1.0)
+    status: Literal["evaluated", "failed"]
+    error: str | None = None
+    model_config = {"frozen": True}

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -15,3 +15,14 @@ def test_help_exits_zero() -> None:
 def test_self_eval_help_exits_zero() -> None:
     result = runner.invoke(app, ["self-eval", "--help"])
     assert result.exit_code == 0
+
+
+def test_evaluate_dry_run() -> None:
+    result = runner.invoke(app, ["evaluate", "myimage:latest", "--dry-run"])
+    assert result.exit_code == 0
+    assert "submission_hash" in result.output or "docker_image" in result.output
+
+
+def test_evaluate_no_dry_run() -> None:
+    result = runner.invoke(app, ["evaluate", "myimage:latest"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- Adds `brain_wrought_harness/models.py` with three frozen pydantic v2 models: `EvaluationConfig`, `AxisResult`, and `EvaluationResult`
- Adds the `evaluate` CLI command to `cli.py` using the `Annotated` pattern; supports `--dry-run` (prints config JSON, exits 0) and non-dry-run (exits 1 with stub message pending Phase 3 Docker integration)
- Adds `test_evaluate_dry_run` and `test_evaluate_no_dry_run` to `tests/test_cli_smoke.py`; all 4 tests pass

## Test plan

- [ ] `python -m pytest tests/ --tb=short` — 4 passed, 0 failed
- [ ] `python -m mypy brain_wrought_harness/ --strict` — no issues found
- [ ] `brain-wrought evaluate myimage:latest --dry-run` prints JSON with `submission_hash` and `docker_image`
- [ ] `brain-wrought evaluate myimage:latest` (no `--dry-run`) exits with code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)