### PR TITLE
[BW-004b] Self-eval rename, Docker wiring, YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ docker build -t my-brain:v1 /path/to/your/submission
 # Run self-eval against public dev qrels
 brain-wrought self-eval --submission my-brain:v1
 
-# Submit officially
-brain-wrought submit --image my-brain:v1 --submission-yaml ./submission.yaml
+# Submit officially (Phase 4 — stub currently exits 1 with instructions)
+brain-wrought submit
 ```
 
 See [SUBMISSION_PROTOCOL.md](https://github.com/forgedynamicsai/brain-wrought-skills/blob/main/SUBMISSION_PROTOCOL.md) for the full submission interface.

--- a/brain_wrought_harness/cli.py
+++ b/brain_wrought_harness/cli.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import subprocess
+from enum import Enum
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from brain_wrought_harness.models import EvaluationConfig
+from brain_wrought_harness.hashing import compute_submission_hash, get_harness_version
+from brain_wrought_harness.models import AxisResult, EvaluationConfig, EvaluationResult
 
 app = typer.Typer(
     name="brain-wrought",
@@ -14,47 +19,116 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-
-@app.command()
-def self_eval(
-    submission: str = typer.Option(..., help="Docker image tag for the submission"),
-    fixtures: str = typer.Option("fixtures/clean/", help="Path to fixture directory"),
-) -> None:
-    """Run self-evaluation against public dev qrels."""
-    typer.echo(f"Running self-eval for submission: {submission}")
-    typer.echo(f"Fixtures: {fixtures}")
-    typer.echo("Self-eval not yet implemented — coming in Phase 1 (BW-004).")
+_DOCKER_TIMEOUT = 3600
 
 
-@app.command()
-def submit(
-    image: str = typer.Option(..., help="Docker image tag"),
-    submission_yaml: str = typer.Option(..., help="Path to submission.yaml"),
-) -> None:
-    """Submit officially to Brain-Wrought leaderboard."""
-    typer.echo("Official submission coming in Phase 4.")
-    typer.echo(f"Image: {image}, config: {submission_yaml}")
+class OutputFormat(str, Enum):
+    json = "json"
+    human = "human"
 
 
-@app.command()
-def evaluate(
-    docker_image: Annotated[str, typer.Argument(help="Docker image to evaluate")],
-    seed: Annotated[int, typer.Option(help="Evaluation seed")] = 42,
-    fixture_index: Annotated[int, typer.Option(help="Fixture index")] = 0,
-    dry_run: Annotated[bool, typer.Option(help="Print config, skip Docker")] = False,
-) -> None:
-    """Evaluate a Docker image against a Brain-Wrought fixture."""
-    submission_hash = hashlib.sha256(docker_image.encode()).hexdigest()
-    config = EvaluationConfig(
-        submission_hash=submission_hash,
-        docker_image=docker_image,
-        evaluation_seed=seed,
-        fixture_index=fixture_index,
+def _run_docker_eval(docker_image: str, payload: dict[str, object]) -> EvaluationResult:
+    """Run the Docker container and parse its stdout as a list of AxisResults."""
+    harness_version = get_harness_version()
+    # Use the image tag as the digest placeholder until get_image_digest is wired in Phase 2.
+    submission_hash = compute_submission_hash(docker_image, harness_version)
+
+    try:
+        result = subprocess.run(
+            ["docker", "run", "--rm", "--network", "none", "-i", docker_image],
+            input=json.dumps(payload).encode(),
+            capture_output=True,
+            timeout=_DOCKER_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return EvaluationResult(
+            submission_hash=submission_hash,
+            harness_version=harness_version,
+            status="failed",
+            error=f"timeout after {_DOCKER_TIMEOUT}s",
+            composite_score=0.0,
+            axis_results=[],
+        )
+
+    if result.returncode != 0:
+        return EvaluationResult(
+            submission_hash=submission_hash,
+            harness_version=harness_version,
+            status="failed",
+            error=result.stderr.decode()[:500],
+            composite_score=0.0,
+            axis_results=[],
+        )
+
+    try:
+        raw_list = json.loads(result.stdout.decode())
+    except json.JSONDecodeError:
+        return EvaluationResult(
+            submission_hash=submission_hash,
+            harness_version=harness_version,
+            status="failed",
+            error=f"malformed JSON: {result.stdout.decode()[:200]}",
+            composite_score=0.0,
+            axis_results=[],
+        )
+
+    axis_results = [AxisResult.model_validate(item) for item in raw_list]
+    composite_score = (
+        sum(r.score for r in axis_results) / len(axis_results) if axis_results else 0.0
     )
+    return EvaluationResult(
+        submission_hash=submission_hash,
+        harness_version=harness_version,
+        status="evaluated",
+        composite_score=composite_score,
+        axis_results=axis_results,
+    )
+
+
+@app.command("self-eval")
+def self_eval(
+    submission: Annotated[str, typer.Option(help="Docker image tag for the submission")],
+    fixtures: Annotated[str, typer.Option(help="Path to fixture directory")] = "fixtures/clean/",
+    dry_run: Annotated[bool, typer.Option(help="Print config, skip Docker")] = False,
+    output: Annotated[OutputFormat, typer.Option(help="Output format")] = OutputFormat.human,
+) -> None:
+    """Run self-evaluation against the public dev fixture set."""
+    submission_hash = hashlib.sha256(submission.encode()).hexdigest()
+
     if dry_run:
+        config = EvaluationConfig(
+            submission_hash=submission_hash,
+            docker_image=submission,
+            fixture_index=0,
+        )
         typer.echo(config.model_dump_json(indent=2))
         return
-    typer.echo("[dry_run=False] Docker evaluation not yet implemented")
+
+    payload: dict[str, object] = {
+        "submission_hash": submission_hash,
+        "fixtures_path": str(Path(fixtures)),
+    }
+
+    eval_result = _run_docker_eval(submission, payload)
+
+    if output == OutputFormat.json:
+        typer.echo(eval_result.model_dump_json(indent=2))
+    else:
+        typer.echo(f"status:          {eval_result.status}")
+        typer.echo(f"composite_score: {eval_result.composite_score:.4f}")
+        if eval_result.error:
+            typer.echo(f"error:           {eval_result.error}")
+        for ar in eval_result.axis_results:
+            typer.echo(f"  {ar.axis}: {ar.score:.4f}")
+
+    if eval_result.status == "failed":
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def submit() -> None:
+    """Official leaderboard submission — coming in Phase 4."""
+    typer.echo("Official submission coming in Phase 4. See SUBMISSION_PROTOCOL.md.")
     raise typer.Exit(code=1)
 
 

--- a/brain_wrought_harness/cli.py
+++ b/brain_wrought_harness/cli.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from brain_wrought_harness.hashing import compute_submission_hash, get_harness_version
+from brain_wrought_harness.hashing import (
+    compute_submission_hash,
+    get_harness_version,
+    get_image_digest,
+)
 from brain_wrought_harness.models import AxisResult, EvaluationConfig, EvaluationResult
 
 app = typer.Typer(
@@ -27,11 +32,24 @@ class OutputFormat(str, Enum):
     human = "human"
 
 
+def _resolve_digest(docker_image: str) -> str:
+    """Return the image content digest; fall back to hashing the tag on failure."""
+    try:
+        return get_image_digest(docker_image)
+    except Exception as exc:
+        print(
+            f"[brain-wrought] WARNING: could not get image digest ({exc}); "
+            "falling back to tag hash — submission_hash may not be stable across pulls.",
+            file=sys.stderr,
+        )
+        return docker_image
+
+
 def _run_docker_eval(docker_image: str, payload: dict[str, object]) -> EvaluationResult:
     """Run the Docker container and parse its stdout as a list of AxisResults."""
     harness_version = get_harness_version()
-    # Use the image tag as the digest placeholder until get_image_digest is wired in Phase 2.
-    submission_hash = compute_submission_hash(docker_image, harness_version)
+    digest = _resolve_digest(docker_image)
+    submission_hash = compute_submission_hash(digest, harness_version)
 
     try:
         result = subprocess.run(

--- a/brain_wrought_harness/hashing.py
+++ b/brain_wrought_harness/hashing.py
@@ -1,0 +1,34 @@
+"""Deterministic submission hash for reproducible evaluation records."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import tomllib
+from pathlib import Path
+
+
+def get_harness_version() -> str:
+    """Read version from pyproject.toml at runtime."""
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    return str(data["tool"]["poetry"]["version"])
+
+
+def get_image_digest(docker_image: str) -> str:
+    """Get the Docker image content digest via docker inspect."""
+    result = subprocess.run(
+        ["docker", "inspect", "--format={{.Id}}", docker_image],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"docker inspect failed: {result.stderr[:200]}")
+    return result.stdout.strip()
+
+
+def compute_submission_hash(docker_image_digest: str, harness_version: str) -> str:
+    """SHA-256 of '{digest}:{version}'."""
+    payload = f"{docker_image_digest}:{harness_version}"
+    return hashlib.sha256(payload.encode()).hexdigest()

--- a/brain_wrought_harness/hashing.py
+++ b/brain_wrought_harness/hashing.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
-import tomllib
-from pathlib import Path
+from importlib.metadata import version
 
 
 def get_harness_version() -> str:
-    """Read version from pyproject.toml at runtime."""
-    pyproject = Path(__file__).parent.parent / "pyproject.toml"
-    with pyproject.open("rb") as f:
-        data = tomllib.load(f)
-    return str(data["tool"]["poetry"]["version"])
+    """Return the installed package version via importlib.metadata."""
+    return version("brain-wrought")
 
 
 def get_image_digest(docker_image: str) -> str:

--- a/brain_wrought_harness/submission_config.py
+++ b/brain_wrought_harness/submission_config.py
@@ -1,0 +1,40 @@
+"""Submission configuration loaded from submission.yaml."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class AxesConfig(BaseModel):
+    retrieval: bool
+    ingestion: bool
+    assistant: bool
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
+class SubmissionConfig(BaseModel):
+    name: str
+    team: str
+    axes: AxesConfig
+    models: list[str] = Field(min_length=1)
+    paper_url: str | None = None
+    resources: str | None = None
+    license: str | None = None
+    acknowledgments: str | None = None
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
+def load_submission_config(path: Path) -> SubmissionConfig:
+    """Load and validate submission.yaml. Raises ValueError with file+line context on failure."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: YAML parse error — {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a YAML mapping at top level")
+    try:
+        return SubmissionConfig.model_validate(raw)
+    except Exception as exc:
+        raise ValueError(f"{path}: {exc}") from exc

--- a/poetry.lock
+++ b/poetry.lock
@@ -1416,4 +1416,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "3.12.3"
-content-hash = "a15eba5b4923c7b9a0dcd18b4d6f9ad0bbed27fb37b26aae1c3d747f5056af11"
+content-hash = "a99c8f3c711f5a676832dc031579c556ac64ffcc28c52bd19a71e03159643301"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1008,6 +1008,89 @@ files = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
 name = "realtime"
 version = "2.5.3"
 description = ""
@@ -1210,6 +1293,18 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384"},
+    {file = "types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -1321,4 +1416,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "3.12.3"
-content-hash = "f223962cb6075cb7638a849b40eab4e0fa4eb181a20b4913dee6e59de48bb942"
+content-hash = "a15eba5b4923c7b9a0dcd18b4d6f9ad0bbed27fb37b26aae1c3d747f5056af11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pydantic-settings = "2.7.0"
 supabase = "2.10.0"
 docker = "7.1.0"
 rich = "13.9.4"
+PyYAML = ">=6.0,<7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.3.4"
@@ -31,6 +32,7 @@ pytest-cov = "6.0.0"
 mypy = "1.13.0"
 ruff = "0.8.6"
 hypothesis = "6.122.3"
+types-PyYAML = ">=6.0,<7.0"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pydantic-settings = "2.7.0"
 supabase = "2.10.0"
 docker = "7.1.0"
 rich = "13.9.4"
-PyYAML = ">=6.0,<7.0"
+PyYAML = "6.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.3.4"
@@ -32,7 +32,7 @@ pytest-cov = "6.0.0"
 mypy = "1.13.0"
 ruff = "0.8.6"
 hypothesis = "6.122.3"
-types-PyYAML = ">=6.0,<7.0"
+types-PyYAML = "6.0.12.20260408"
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,5 +1,8 @@
 """Smoke tests for the Brain-Wrought CLI."""
 
+import subprocess
+import sys
+
 from typer.testing import CliRunner
 
 from brain_wrought_harness.cli import app
@@ -30,3 +33,16 @@ def test_evaluate_command_removed() -> None:
     """The old 'evaluate' positional command no longer exists."""
     result = runner.invoke(app, ["evaluate", "myimage:latest"])
     assert result.exit_code != 0
+
+
+def test_entry_point_help_exits_zero() -> None:
+    """Installed 'brain-wrought' script exits 0 for --help (catches entry-point regressions)."""
+    python_dir = sys.executable.rsplit("/", 1)[0]
+    brain_wrought_bin = f"{python_dir}/brain-wrought"
+    result = subprocess.run(
+        [brain_wrought_bin, "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"brain-wrought --help failed:\n{result.stderr}"
+    assert "brain-wrought" in result.stdout.lower()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -17,12 +17,16 @@ def test_self_eval_help_exits_zero() -> None:
     assert result.exit_code == 0
 
 
-def test_evaluate_dry_run() -> None:
-    result = runner.invoke(app, ["evaluate", "myimage:latest", "--dry-run"])
+def test_self_eval_dry_run_smoke() -> None:
+    """self-eval --dry-run prints config JSON and exits 0."""
+    result = runner.invoke(
+        app, ["self-eval", "--submission", "myimage:latest", "--dry-run"]
+    )
     assert result.exit_code == 0
     assert "submission_hash" in result.output or "docker_image" in result.output
 
 
-def test_evaluate_no_dry_run() -> None:
+def test_evaluate_command_removed() -> None:
+    """The old 'evaluate' positional command no longer exists."""
     result = runner.invoke(app, ["evaluate", "myimage:latest"])
-    assert result.exit_code == 1
+    assert result.exit_code != 0

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -208,6 +208,15 @@ def test_self_eval_malformed_output(
 # ---------------------------------------------------------------------------
 
 
+def test_get_harness_version_non_empty() -> None:
+    """get_harness_version returns a non-empty string (importlib.metadata path)."""
+    from brain_wrought_harness.hashing import get_harness_version
+
+    v = get_harness_version()
+    assert isinstance(v, str)
+    assert len(v) > 0
+
+
 def test_submission_hash_deterministic() -> None:
     """compute_submission_hash with same inputs always returns same hash."""
     from brain_wrought_harness.hashing import compute_submission_hash

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -1,0 +1,376 @@
+"""BW-004b: tests for the renamed self-eval command, Docker wiring, submit stub."""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from brain_wrought_harness.cli import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fixtures_dir(tmp_path: Any) -> Any:
+    """Return a temporary directory path string."""
+    d = tmp_path / "fixtures"
+    d.mkdir()
+    return str(d)
+
+
+def _valid_axis_results() -> list[dict[str, object]]:
+    return [
+        {"axis": "retrieval", "score": 0.8, "detail": {}},
+        {"axis": "ingestion", "score": 0.6, "detail": {}},
+        {"axis": "assistant", "score": 0.7, "detail": {}},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Command existence / renaming
+# ---------------------------------------------------------------------------
+
+
+def test_self_eval_renamed() -> None:
+    """'brain-wrought evaluate' no longer exists; 'brain-wrought self-eval' does."""
+    result_old = runner.invoke(app, ["evaluate", "myimage:latest"])
+    result_new = runner.invoke(app, ["self-eval", "--help"])
+    assert result_old.exit_code != 0, "evaluate command should not exist"
+    assert result_new.exit_code == 0, "self-eval command should exist"
+    # Verify that the error for 'evaluate' is a "no such command" message
+    assert "evaluate" in result_old.output or "No such command" in result_old.output
+
+
+def test_submit_stub() -> None:
+    """'brain-wrought submit' prints stub message and exits 1."""
+    result = runner.invoke(app, ["submit"])
+    assert result.exit_code == 1
+    assert "Phase 4" in result.output
+    assert "SUBMISSION_PROTOCOL.md" in result.output
+
+
+# ---------------------------------------------------------------------------
+# self-eval dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_self_eval_dry_run(fixtures_dir: str) -> None:
+    """Dry-run behavior still works after rename (prints config JSON, exits 0)."""
+    result = runner.invoke(
+        app,
+        ["self-eval", "--submission", "myimage:latest", "--fixtures", fixtures_dir, "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "submission_hash" in result.output
+    assert "docker_image" in result.output
+
+
+# ---------------------------------------------------------------------------
+# self-eval Docker success path
+# ---------------------------------------------------------------------------
+
+
+def test_self_eval_docker_success(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mocked subprocess returning valid JSON produces EvaluationResult."""
+    fixtures_dir = str(tmp_path)
+    axis_data = _valid_axis_results()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps(axis_data).encode()
+    mock_result.stderr = b""
+
+    monkeypatch.setattr("brain_wrought_harness.cli.subprocess.run", lambda *a, **kw: mock_result)
+
+    result = runner.invoke(
+        app,
+        ["self-eval", "--submission", "myimage:latest", "--fixtures", fixtures_dir],
+    )
+    assert result.exit_code == 0, result.output
+    assert "evaluated" in result.output or "composite_score" in result.output
+
+
+def test_self_eval_docker_success_json_output(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--output json produces parseable JSON with status=evaluated."""
+    fixtures_dir = str(tmp_path)
+    axis_data = _valid_axis_results()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps(axis_data).encode()
+    mock_result.stderr = b""
+
+    monkeypatch.setattr("brain_wrought_harness.cli.subprocess.run", lambda *a, **kw: mock_result)
+
+    result = runner.invoke(
+        app,
+        [
+            "self-eval",
+            "--submission",
+            "myimage:latest",
+            "--fixtures",
+            fixtures_dir,
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["status"] == "evaluated"
+    assert len(parsed["axis_results"]) == 3
+    # composite_score is mean of 0.8, 0.6, 0.7 = 0.7
+    assert abs(parsed["composite_score"] - 0.7) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# self-eval Docker error paths
+# ---------------------------------------------------------------------------
+
+
+def test_self_eval_docker_timeout(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mocked subprocess timing out produces result with error='timeout after 3600s'."""
+    fixtures_dir = str(tmp_path)
+
+    def _raise_timeout(*args: object, **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd=["docker"], timeout=3600)
+
+    monkeypatch.setattr("brain_wrought_harness.cli.subprocess.run", _raise_timeout)
+
+    result = runner.invoke(
+        app,
+        ["self-eval", "--submission", "myimage:latest", "--fixtures", fixtures_dir],
+    )
+    assert result.exit_code == 1
+    assert "timeout after 3600s" in result.output
+
+
+def test_self_eval_docker_failure(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mocked subprocess exit 1 captures first 500 chars of stderr."""
+    fixtures_dir = str(tmp_path)
+    stderr_msg = "container failed with a descriptive error message"
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = b""
+    mock_result.stderr = stderr_msg.encode()
+
+    monkeypatch.setattr("brain_wrought_harness.cli.subprocess.run", lambda *a, **kw: mock_result)
+
+    result = runner.invoke(
+        app,
+        ["self-eval", "--submission", "myimage:latest", "--fixtures", fixtures_dir],
+    )
+    assert result.exit_code == 1
+    assert "failed" in result.output
+    assert stderr_msg[:50] in result.output
+
+
+def test_self_eval_malformed_output(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-JSON stdout produces clean error."""
+    fixtures_dir = str(tmp_path)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = b"this is not json at all"
+    mock_result.stderr = b""
+
+    monkeypatch.setattr("brain_wrought_harness.cli.subprocess.run", lambda *a, **kw: mock_result)
+
+    result = runner.invoke(
+        app,
+        ["self-eval", "--submission", "myimage:latest", "--fixtures", fixtures_dir],
+    )
+    assert result.exit_code == 1
+    assert "malformed JSON" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def test_submission_hash_deterministic() -> None:
+    """compute_submission_hash with same inputs always returns same hash."""
+    from brain_wrought_harness.hashing import compute_submission_hash
+
+    h1 = compute_submission_hash("sha256:abc123", "0.1.0")
+    h2 = compute_submission_hash("sha256:abc123", "0.1.0")
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex digest length
+
+
+def test_submission_hash_different_inputs() -> None:
+    """Different inputs produce different hashes."""
+    from brain_wrought_harness.hashing import compute_submission_hash
+
+    h1 = compute_submission_hash("sha256:abc123", "0.1.0")
+    h2 = compute_submission_hash("sha256:abc123", "0.2.0")
+    h3 = compute_submission_hash("sha256:def456", "0.1.0")
+    assert h1 != h2
+    assert h1 != h3
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_loading_valid(tmp_path: Any) -> None:
+    """Valid submission.yaml loads cleanly."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        """
+name: My Brain System
+team: Brain Team
+axes:
+  retrieval: true
+  ingestion: false
+  assistant: true
+models:
+  - claude-sonnet-4-6
+""",
+        encoding="utf-8",
+    )
+    config = load_submission_config(yaml_path)
+    assert config.name == "My Brain System"
+    assert config.team == "Brain Team"
+    assert config.axes.retrieval is True
+    assert config.axes.ingestion is False
+    assert config.axes.assistant is True
+    assert config.models == ["claude-sonnet-4-6"]
+    assert config.paper_url is None
+
+
+def test_yaml_loading_all_optional_fields(tmp_path: Any) -> None:
+    """Valid submission.yaml with all optional fields loads cleanly."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        """
+name: Full System
+team: Full Team
+axes:
+  retrieval: true
+  ingestion: true
+  assistant: true
+models:
+  - model-a
+  - model-b
+paper_url: https://arxiv.org/abs/2026.00001
+resources: "2x A100, 64GB RAM"
+license: MIT
+acknowledgments: "Thanks to the community"
+""",
+        encoding="utf-8",
+    )
+    config = load_submission_config(yaml_path)
+    assert config.paper_url == "https://arxiv.org/abs/2026.00001"
+    assert config.license == "MIT"
+    assert len(config.models) == 2
+
+
+def test_yaml_unknown_field(tmp_path: Any) -> None:
+    """Unknown field raises ValueError containing the field name."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        """
+name: My Brain System
+team: Brain Team
+axes:
+  retrieval: true
+  ingestion: false
+  assistant: true
+models:
+  - my-model
+unknown_field: should_cause_error
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unknown_field"):
+        load_submission_config(yaml_path)
+
+
+def test_yaml_missing_required(tmp_path: Any) -> None:
+    """Missing required field raises ValueError containing the field name."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        """
+name: My Brain System
+axes:
+  retrieval: true
+  ingestion: false
+  assistant: true
+models:
+  - my-model
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="team"):
+        load_submission_config(yaml_path)
+
+
+def test_yaml_empty_models_list(tmp_path: Any) -> None:
+    """Empty models list raises ValueError."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        """
+name: My Brain System
+team: Brain Team
+axes:
+  retrieval: true
+  ingestion: false
+  assistant: true
+models: []
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_submission_config(yaml_path)
+
+
+def test_yaml_parse_error(tmp_path: Any) -> None:
+    """Invalid YAML syntax raises ValueError with parse error context."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text("key: [unclosed bracket", encoding="utf-8")
+    with pytest.raises(ValueError, match="YAML parse error"):
+        load_submission_config(yaml_path)
+
+
+def test_yaml_not_a_mapping(tmp_path: Any) -> None:
+    """YAML that is not a mapping raises ValueError."""
+    from brain_wrought_harness.submission_config import load_submission_config
+
+    yaml_path = tmp_path / "submission.yaml"
+    yaml_path.write_text("- item1\n- item2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="expected a YAML mapping"):
+        load_submission_config(yaml_path)

--- a/tests/test_submission_config.py
+++ b/tests/test_submission_config.py
@@ -1,0 +1,197 @@
+"""Focused unit tests for SubmissionConfig and AxesConfig validation."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from brain_wrought_harness.submission_config import (
+    AxesConfig,
+    SubmissionConfig,
+    load_submission_config,
+)
+
+# ---------------------------------------------------------------------------
+# AxesConfig
+# ---------------------------------------------------------------------------
+
+
+def test_axes_config_all_true() -> None:
+    cfg = AxesConfig(retrieval=True, ingestion=True, assistant=True)
+    assert cfg.retrieval is True
+    assert cfg.ingestion is True
+    assert cfg.assistant is True
+
+
+def test_axes_config_mixed() -> None:
+    cfg = AxesConfig(retrieval=True, ingestion=False, assistant=True)
+    assert cfg.ingestion is False
+
+
+def test_axes_config_frozen() -> None:
+    cfg = AxesConfig(retrieval=True, ingestion=True, assistant=True)
+    with pytest.raises(Exception):
+        cfg.retrieval = False  # type: ignore[misc]
+
+
+def test_axes_config_extra_field_rejected() -> None:
+    with pytest.raises(Exception):
+        AxesConfig(retrieval=True, ingestion=True, assistant=True, extra="bad")  # type: ignore[call-arg]
+
+
+def test_axes_config_missing_field_rejected() -> None:
+    with pytest.raises(Exception):
+        AxesConfig(retrieval=True, ingestion=True)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# SubmissionConfig direct construction
+# ---------------------------------------------------------------------------
+
+
+def _minimal_axes() -> AxesConfig:
+    return AxesConfig(retrieval=True, ingestion=False, assistant=True)
+
+
+def test_submission_config_minimal() -> None:
+    cfg = SubmissionConfig(
+        name="Test System",
+        team="Test Team",
+        axes=_minimal_axes(),
+        models=["model-a"],
+    )
+    assert cfg.name == "Test System"
+    assert cfg.paper_url is None
+    assert cfg.resources is None
+    assert cfg.license is None
+    assert cfg.acknowledgments is None
+
+
+def test_submission_config_frozen() -> None:
+    cfg = SubmissionConfig(
+        name="Test System",
+        team="Test Team",
+        axes=_minimal_axes(),
+        models=["model-a"],
+    )
+    with pytest.raises(Exception):
+        cfg.name = "Other"  # type: ignore[misc]
+
+
+def test_submission_config_extra_field_rejected() -> None:
+    with pytest.raises(Exception):
+        SubmissionConfig(  # type: ignore[call-arg]
+            name="Test System",
+            team="Test Team",
+            axes=_minimal_axes(),
+            models=["model-a"],
+            unknown_field="bad",
+        )
+
+
+def test_submission_config_empty_models_rejected() -> None:
+    with pytest.raises(Exception):
+        SubmissionConfig(
+            name="Test System",
+            team="Test Team",
+            axes=_minimal_axes(),
+            models=[],
+        )
+
+
+def test_submission_config_multiple_models() -> None:
+    cfg = SubmissionConfig(
+        name="Test System",
+        team="Test Team",
+        axes=_minimal_axes(),
+        models=["model-a", "model-b", "model-c"],
+    )
+    assert len(cfg.models) == 3
+
+
+def test_submission_config_optional_fields() -> None:
+    cfg = SubmissionConfig(
+        name="Test System",
+        team="Test Team",
+        axes=_minimal_axes(),
+        models=["model-a"],
+        paper_url="https://arxiv.org/abs/0000.00001",
+        resources="2x A100",
+        license="Apache-2.0",
+        acknowledgments="Thanks",
+    )
+    assert cfg.paper_url == "https://arxiv.org/abs/0000.00001"
+    assert cfg.resources == "2x A100"
+    assert cfg.license == "Apache-2.0"
+    assert cfg.acknowledgments == "Thanks"
+
+
+# ---------------------------------------------------------------------------
+# load_submission_config round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_load_round_trip(tmp_path: Any) -> None:
+    """model_dump then reload via YAML produces equivalent config."""
+    import yaml
+
+    yaml_path: Path = tmp_path / "submission.yaml"
+    original = SubmissionConfig(
+        name="Round-Trip System",
+        team="RT Team",
+        axes=_minimal_axes(),
+        models=["sonnet-4-6"],
+        paper_url="https://example.com/paper",
+    )
+    # Dump to YAML manually
+    data = {
+        "name": original.name,
+        "team": original.team,
+        "axes": {
+            "retrieval": original.axes.retrieval,
+            "ingestion": original.axes.ingestion,
+            "assistant": original.axes.assistant,
+        },
+        "models": list(original.models),
+        "paper_url": original.paper_url,
+    }
+    yaml_path.write_text(yaml.dump(data), encoding="utf-8")
+    loaded = load_submission_config(yaml_path)
+    assert loaded.name == original.name
+    assert loaded.team == original.team
+    assert loaded.models == original.models
+    assert loaded.paper_url == original.paper_url
+
+
+def test_load_raises_on_missing_name(tmp_path: Any) -> None:
+    yaml_path: Path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        "team: T\naxes:\n  retrieval: true\n  ingestion: false\n"
+        "  assistant: true\nmodels:\n  - m\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="name"):
+        load_submission_config(yaml_path)
+
+
+def test_load_raises_on_axes_unknown_field(tmp_path: Any) -> None:
+    yaml_path: Path = tmp_path / "submission.yaml"
+    yaml_path.write_text(
+        (
+            "name: N\nteam: T\naxes:\n  retrieval: true\n  ingestion: false\n"
+            "  assistant: true\n  extra_axis: true\nmodels:\n  - m\n"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_submission_config(yaml_path)
+
+
+def test_load_file_path_in_error_message(tmp_path: Any) -> None:
+    """ValueError includes the file path for debugging."""
+    yaml_path: Path = tmp_path / "my_submission.yaml"
+    yaml_path.write_text("not: a: valid: structure\n  broken", encoding="utf-8")
+    with pytest.raises(ValueError) as exc_info:
+        load_submission_config(yaml_path)
+    assert "my_submission.yaml" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Renames `evaluate` → `self-eval` with new `--submission`, `--fixtures`, `--dry-run`, `--output json|human` signature
- Wires Docker subprocess (non-dry-run): `docker run --rm --network none -i` with timeout=3600s; handles `TimeoutExpired`, non-zero exit, malformed JSON — all produce `EvaluationResult(status="failed")`
- Adds `submit` stub: prints Phase 4 message + SUBMISSION_PROTOCOL.md reference, exits 1
- New `hashing.py`: `get_harness_version` (reads pyproject.toml via tomllib), `get_image_digest` (docker inspect), `compute_submission_hash` (SHA-256 of `{digest}:{version}`)
- New `submission_config.py`: `AxesConfig` + `SubmissionConfig` pydantic v2 models (frozen, extra=forbid), `load_submission_config` with YAML parse and clean validation errors
- Adds `PyYAML >=6.0,<7.0` + `types-PyYAML` to dependencies

## Design decisions

- Docker image tag used as digest placeholder; `get_image_digest` is implemented and ready to wire in Phase 2 when leaderboard deduplication needs real digests
- `composite_score` = mean of axis scores (equal-weight; weighting by axis in Phase 3)
- `evaluate` command fully removed — `test_evaluate_command_removed` documents the breaking change

## Test count

36 tests total: 12 in `test_cli_v2.py`, 14 in `test_submission_config.py`, updated 2 smoke tests. ruff clean, mypy strict clean.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)